### PR TITLE
VJNP-78: 답변 피드 카드 추가 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,12 +3,7 @@
     "browser": true,
     "es2021": true
   },
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended",
-    "plugin:prettier/recommended",
-    "plugin:jsx-a11y/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:prettier/recommended"],
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true

--- a/src/apis/postReaction.js
+++ b/src/apis/postReaction.js
@@ -1,0 +1,22 @@
+import { QUESTIONS_QUERY_KEY, REACTION_QUERY_KEY } from '../constants/queryKeys';
+import { axiosInstance } from './axiosSetup';
+
+/**
+ * 답변 id와 내용을 받아 서버로 답변 수정 요청을 하는 함수
+ * @param {string} questionId 질문 id
+ * @param {string} type 리액션 타입
+ * @returns {object | null} 응답 객체
+ */
+const postReaction = async ({ questionId, type }) => {
+  try {
+    const { data } = await axiosInstance.post(`/${QUESTIONS_QUERY_KEY}/${questionId}/${REACTION_QUERY_KEY}/`, {
+      type: type,
+    });
+
+    return data;
+  } catch (error) {
+    return null;
+  }
+};
+
+export default postReaction;

--- a/src/apis/putAnswer.js
+++ b/src/apis/putAnswer.js
@@ -7,11 +7,11 @@ import { axiosInstance } from './axiosSetup';
  * @param {string} content 답변 내용
  * @returns {object | null} 응답 객체
  */
-const putAnswer = async ({ answerId, content }) => {
+const putAnswer = async ({ answerId, content, isRejected = false }) => {
   try {
     const { data } = await axiosInstance.put(`${ANSWERS_QUERY_KEY}/${answerId}/`, {
       content: content,
-      isRejected: false,
+      isRejected: isRejected,
     });
 
     return data;

--- a/src/apis/putAnswer.js
+++ b/src/apis/putAnswer.js
@@ -8,11 +8,17 @@ import { axiosInstance } from './axiosSetup';
  * @returns {object | null} 응답 객체
  */
 const putAnswer = async ({ answerId, content, isRejected = false }) => {
+  const requestBody = content
+    ? {
+        content: content,
+        isRejected: isRejected,
+      }
+    : {
+        isRejected: isRejected,
+      };
+
   try {
-    const { data } = await axiosInstance.put(`${ANSWERS_QUERY_KEY}/${answerId}/`, {
-      content: content,
-      isRejected: isRejected,
-    });
+    const { data } = await axiosInstance.put(`${ANSWERS_QUERY_KEY}/${answerId}/`, requestBody);
 
     return data;
   } catch (error) {

--- a/src/components/feed/AnswerStatus.jsx
+++ b/src/components/feed/AnswerStatus.jsx
@@ -5,8 +5,8 @@ import styled from 'styled-components';
  * @param props
  * @param {string} props.isHasAnswer 답변 유무
  */
-function AnswerStatus({ isHasAnswer }) {
-  const answerStatus = isHasAnswer ? '답변 완료' : '미답변';
+function AnswerStatus({ isComplete }) {
+  const answerStatus = isComplete ? '답변 완료' : '미답변';
   return <StyledAnswerStatus>{answerStatus}</StyledAnswerStatus>;
 }
 

--- a/src/components/feed/AnswerTemplate.jsx
+++ b/src/components/feed/AnswerTemplate.jsx
@@ -9,7 +9,8 @@ import getElapsedPeriod from '../../utils/getElapsedPeriod';
  * @param {string} props.answerCreatedAt 답변 생성 시기
  */
 function AnswerTemplate({ children, answerCreatedAt }) {
-  const { imageSource, name } = sessionStorage.getItem('profile') || { imageSource: profileImg, name: '아초는 고양이' };
+  const profile = JSON.parse(sessionStorage.getItem('profile'));
+  const { imageSource, name } = profile || { imageSource: profileImg, name: '아초는 고양이' };
   const elapsedPeriod = answerCreatedAt ? getElapsedPeriod(answerCreatedAt) : ''; // 아직 답변이 없는 경우
 
   return (

--- a/src/components/feed/Reaction.jsx
+++ b/src/components/feed/Reaction.jsx
@@ -5,6 +5,12 @@ import { jelloHorizontalAnimation, shakeLeftAnimation } from '../../styles/feed/
 import { useState } from 'react';
 import useSelectReactionMutation from '../../queries/useReactionMutation';
 
+const LIKE_ICON_FILTER =
+  'brightness(0) saturate(100%) invert(51%) sepia(61%) saturate(7062%) hue-rotate(203deg) brightness(97%) contrast(95%)';
+
+const DISLIKE_ICON_FILTER =
+  'brightness(0) saturate(100%) invert(27%) sepia(26%) saturate(3214%) hue-rotate(330deg) brightness(103%) contrast(101%)';
+
 /**
  * 좋아요 싫어요를 보여주고 선택할 수 있다
  * @param props
@@ -81,10 +87,7 @@ const StyledReactionButton = styled.button`
     color: ${({ $reactedType }) => $reactedType === 'like' && 'var(--blue)'};
 
     & .like-icon {
-      filter: ${({ $reactedType }) =>
-        $reactedType === 'like' &&
-        `brightness(0) saturate(100%) invert(51%) sepia(61%) saturate(7062%) hue-rotate(203deg) brightness(97%)
-          contrast(95%)`};
+      filter: ${({ $reactedType }) => $reactedType === 'like' && LIKE_ICON_FILTER};
     }
   }
 
@@ -92,10 +95,7 @@ const StyledReactionButton = styled.button`
     color: ${({ $reactedType }) => $reactedType === 'dislike' && 'var(--red)'};
 
     & .dislike-icon {
-      filter: ${({ $reactedType }) =>
-        $reactedType === 'dislike' &&
-        `brightness(0) saturate(100%) invert(27%) sepia(26%) saturate(3214%) hue-rotate(330deg) brightness(103%)
-          contrast(101%)`};
+      filter: ${({ $reactedType }) => $reactedType === 'dislike' && DISLIKE_ICON_FILTER};
     }
   }
 
@@ -107,16 +107,14 @@ const StyledReactionButton = styled.button`
 
       & .like-icon {
         ${({ $reactedType }) => ($reactedType === 'like' ? jelloHorizontalAnimation : shakeLeftAnimation)}
-        filter: brightness(0) saturate(100%) invert(51%) sepia(61%) saturate(7062%) hue-rotate(203deg) brightness(97%)
-          contrast(95%);
+        filter: ${LIKE_ICON_FILTER};
       }
     }
 
     &.dislike-button {
       color: var(--red);
       & .dislike-icon {
-        filter: brightness(0) saturate(100%) invert(27%) sepia(26%) saturate(3214%) hue-rotate(330deg) brightness(103%)
-          contrast(101%);
+        filter: ${DISLIKE_ICON_FILTER};
       }
     }
   }

--- a/src/components/feed/Reaction.jsx
+++ b/src/components/feed/Reaction.jsx
@@ -1,15 +1,9 @@
-import { css, styled } from 'styled-components';
+import { styled } from 'styled-components';
 import likeIcon from '../../assets/images/like-icon.png';
 import dislikeIcon from '../../assets/images/dislike-icon.png';
-import {
-  jelloHorizontal,
-  jelloHorizontalAnimation,
-  shakeLeft,
-  shakeLeftAnimation,
-} from '../../styles/feed/feedCardStyles';
+import { jelloHorizontalAnimation, shakeLeftAnimation } from '../../styles/feed/feedCardStyles';
 import { useState } from 'react';
 import useSelectReactionMutation from '../../queries/useReactionMutation';
-import { useEffect } from 'react';
 
 /**
  * 좋아요 싫어요를 보여주고 선택할 수 있다
@@ -95,7 +89,7 @@ const StyledReactionButton = styled.button`
   }
 
   &.dislike-button {
-    color: ${({ $reactedType }) => $reactedType === 'like' && 'var(--red)'};
+    color: ${({ $reactedType }) => $reactedType === 'dislike' && 'var(--red)'};
 
     & .dislike-icon {
       filter: ${({ $reactedType }) =>

--- a/src/components/feed/Reaction.jsx
+++ b/src/components/feed/Reaction.jsx
@@ -21,7 +21,7 @@ const DISLIKE_ICON_FILTER =
 function Reaction({ likeCount, dislikeCount, questionId }) {
   const reactionObject = JSON.parse(localStorage.getItem('reactionObject'));
   const [reactedType, setReactedType] = useState((questionId && reactionObject[questionId]) || '');
-  const [like, setLike] = useState(likeCount);
+  const [currentCount, setCurrentCount] = useState({ like: likeCount, dislike: dislikeCount });
   const { mutate } = useSelectReactionMutation();
 
   const handleReactionButtonClick = event => {
@@ -29,16 +29,10 @@ function Reaction({ likeCount, dislikeCount, questionId }) {
 
     if (questionId && !reactedType) {
       localStorage.setItem('reactionObject', JSON.stringify({ [questionId]: type }));
-      setReactedType('like');
+      setReactedType(type);
+      setCurrentCount(prevState => ({ ...prevState, [type]: prevState[type] + 1 }));
 
-      mutate(
-        { questionId: questionId, type: type },
-        {
-          onSuccess: data => {
-            setLike(data.like);
-          },
-        }
-      );
+      mutate({ questionId: questionId, type: type });
     }
   };
 
@@ -51,7 +45,7 @@ function Reaction({ likeCount, dislikeCount, questionId }) {
         onClick={handleReactionButtonClick}>
         <img className={'like-icon'} src={likeIcon} alt={'좋아요 아이콘'} />
         <span>좋아요</span>
-        <span>{like}</span>
+        <span>{currentCount.like}</span>
       </StyledReactionButton>
       <StyledReactionButton className={'dislike-button'} data-type={'dislike'} onClick={handleReactionButtonClick}>
         <img className={'dislike-icon'} src={dislikeIcon} alt={'싫어요 아이콘'} />

--- a/src/components/feed/Reaction.jsx
+++ b/src/components/feed/Reaction.jsx
@@ -1,51 +1,135 @@
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 import likeIcon from '../../assets/images/like-icon.png';
 import dislikeIcon from '../../assets/images/dislike-icon.png';
+import {
+  jelloHorizontal,
+  jelloHorizontalAnimation,
+  shakeLeft,
+  shakeLeftAnimation,
+} from '../../styles/feed/feedCardStyles';
+import { useState } from 'react';
+import useSelectReactionMutation from '../../queries/useReactionMutation';
+import { useEffect } from 'react';
 
 /**
  * 좋아요 싫어요를 보여주고 선택할 수 있다
  * @param props
  * @param {integer} props.likeCount 좋아요 수
  * @param {integer} props.dislikeCount 싫어요 수
+ * @param {string} props.questionId 질문 id
  */
-function Reaction({ likeCount, dislikeCount }) {
+function Reaction({ likeCount, dislikeCount, questionId }) {
+  const reactionObject = JSON.parse(localStorage.getItem('reactionObject'));
+  const [reactedType, setReactedType] = useState((questionId && reactionObject[questionId]) || '');
+  const [like, setLike] = useState(likeCount);
+  const { mutate } = useSelectReactionMutation();
+
+  const handleReactionButtonClick = event => {
+    const { type } = event.currentTarget.dataset;
+
+    if (questionId && !reactedType) {
+      localStorage.setItem('reactionObject', JSON.stringify({ [questionId]: type }));
+      setReactedType('like');
+
+      mutate(
+        { questionId: questionId, type: type },
+        {
+          onSuccess: data => {
+            setLike(data.like);
+          },
+        }
+      );
+    }
+  };
+
   return (
-    <StyledReactionArea>
-      <article>
-        <img src={likeIcon} alt={'좋아요 아이콘'} />
+    <StyledReactionContainer>
+      <StyledReactionButton
+        className={'like-button'}
+        data-type={'like'}
+        $reactedType={reactedType}
+        onClick={handleReactionButtonClick}>
+        <img className={'like-icon'} src={likeIcon} alt={'좋아요 아이콘'} />
         <span>좋아요</span>
-        <span>{likeCount}</span>
-      </article>
-      <article>
-        <img src={dislikeIcon} alt={'싫어요 아이콘'} />
+        <span>{like}</span>
+      </StyledReactionButton>
+      <StyledReactionButton className={'dislike-button'} data-type={'dislike'} onClick={handleReactionButtonClick}>
+        <img className={'dislike-icon'} src={dislikeIcon} alt={'싫어요 아이콘'} />
         <span>싫어요</span>
-      </article>
-    </StyledReactionArea>
+      </StyledReactionButton>
+    </StyledReactionContainer>
   );
 }
 
 export default Reaction;
 
-const StyledReactionArea = styled.section`
+const StyledReactionContainer = styled.section`
   display: flex;
-  gap: 32px;
-  height: 42px;
-  align-items: flex-end;
+  gap: 15px;
+  align-items: center;
   border-top: 1px solid var(--gray30);
+  padding-top: 15px;
+`;
 
-  & article {
-    display: flex;
-    gap: 6px;
+const StyledReactionButton = styled.button`
+  display: flex;
+  gap: 6px;
+  /* background-color: red; */
+  padding: 10px 8px;
+  border-radius: 30px;
 
-    font-family: Pretendard;
-    font-size: 14px;
-    font-weight: 500;
-    line-height: 18px;
-    text-align: left;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  text-align: left;
 
-    & img {
-      width: 16px;
-      height: 16px;
+  &.like-button {
+    color: ${({ $reactedType }) => $reactedType === 'like' && 'var(--blue)'};
+
+    & .like-icon {
+      filter: ${({ $reactedType }) =>
+        $reactedType === 'like' &&
+        `brightness(0) saturate(100%) invert(51%) sepia(61%) saturate(7062%) hue-rotate(203deg) brightness(97%)
+          contrast(95%)`};
     }
+  }
+
+  &.dislike-button {
+    color: ${({ $reactedType }) => $reactedType === 'like' && 'var(--red)'};
+
+    & .dislike-icon {
+      filter: ${({ $reactedType }) =>
+        $reactedType === 'dislike' &&
+        `brightness(0) saturate(100%) invert(27%) sepia(26%) saturate(3214%) hue-rotate(330deg) brightness(103%)
+          contrast(101%)`};
+    }
+  }
+
+  &:hover {
+    cursor: pointer;
+
+    &.like-button {
+      color: var(--blue);
+
+      & .like-icon {
+        ${({ $reactedType }) => ($reactedType === 'like' ? jelloHorizontalAnimation : shakeLeftAnimation)}
+        filter: brightness(0) saturate(100%) invert(51%) sepia(61%) saturate(7062%) hue-rotate(203deg) brightness(97%)
+          contrast(95%);
+      }
+    }
+
+    &.dislike-button {
+      color: var(--red);
+      & .dislike-icon {
+        filter: brightness(0) saturate(100%) invert(27%) sepia(26%) saturate(3214%) hue-rotate(330deg) brightness(103%)
+          contrast(101%);
+      }
+    }
+  }
+
+  & .like-icon,
+  .dislike-icon {
+    width: 16px;
+    height: 16px;
   }
 `;

--- a/src/components/feed/answerFeed/AnswerCard.jsx
+++ b/src/components/feed/answerFeed/AnswerCard.jsx
@@ -34,6 +34,7 @@ function AnswerCard({
   const [answerCreatedAt, setAnswerCreatedAt] = useState(answer ? answer.createdAt : '');
   const [isEditing, setIsEditing] = useState(false);
   const [isRejected, setIsRejected] = useState(answer ? answer.isRejected : false);
+
   const { mutate: createAnswerMutate } = useCreateAnswerMutation();
   const { mutate: updateAnswerMutate } = useUpdateAnswerMutation();
 
@@ -65,7 +66,7 @@ function AnswerCard({
     event.preventDefault();
 
     setIsRejected(prevState => {
-      // updateAnswerMutate({ answerId: answer.id, content: inputText, isRejected: !prevState });
+      updateAnswerMutate({ answerId: answer.id, isRejected: !prevState });
       return !prevState;
     });
   };

--- a/src/components/feed/answerFeed/AnswerCard.jsx
+++ b/src/components/feed/answerFeed/AnswerCard.jsx
@@ -33,6 +33,7 @@ function AnswerCard({
   const [currentAnswer, setCurrentAnswer] = useState(isHasAnswer ? answer.content : '');
   const [answerCreatedAt, setAnswerCreatedAt] = useState(answer ? answer.createdAt : '');
   const [isEditing, setIsEditing] = useState(false);
+  const [isRejected, setIsRejected] = useState(answer ? answer.isRejected : false);
   const { mutate: createAnswerMutate } = useCreateAnswerMutation();
   const { mutate: updateAnswerMutate } = useUpdateAnswerMutation();
 
@@ -43,26 +44,34 @@ function AnswerCard({
   const handleCreateFormSubmit = (event, inputText) => {
     event.preventDefault();
 
+    setCurrentAnswer(inputText);
     createAnswerMutate(
       { questionId: questionId, content: inputText },
       {
         onSuccess: data => data && setAnswerCreatedAt(data.createdAt),
       }
     );
-
-    setCurrentAnswer(inputText);
   };
 
   const handleEditFormSubmit = (event, inputText) => {
     event.preventDefault();
 
-    updateAnswerMutate({ answerId: answer.id, content: inputText });
-    setIsEditing(false);
     setCurrentAnswer(inputText);
+    setIsEditing(false);
+    updateAnswerMutate({ answerId: answer.id, content: inputText });
+  };
+
+  const handleRejectButtonToggle = event => {
+    event.preventDefault();
+
+    setIsRejected(prevState => {
+      // updateAnswerMutate({ answerId: answer.id, content: inputText, isRejected: !prevState });
+      return !prevState;
+    });
   };
 
   const renderAnswerContent = () => {
-    if (answer?.isRejected) {
+    if (isRejected) {
       // 답변 거절의 경우
       return <StyledAnswerText $isRejected>답변 거절</StyledAnswerText>;
     }
@@ -84,8 +93,8 @@ function AnswerCard({
   return (
     <StyledFeedCardContainer>
       <StyledAnswerCardUpperArea>
-        <AnswerStatus isHasAnswer={isHasAnswer} />
-        <MoreButton handleEditButtonClick={handleEditButtonClick} />
+        <AnswerStatus isComplete={isHasAnswer || isRejected} />
+        <MoreButton onEditButtonClick={handleEditButtonClick} onRejectButtonToggle={handleRejectButtonToggle} />
       </StyledAnswerCardUpperArea>
       <QuestionTitle question={questionContent} questionCreateAt={questionCreateAt} />
       <AnswerTemplate answerCreatedAt={answerCreatedAt}>{renderAnswerContent()}</AnswerTemplate>

--- a/src/components/feed/answerFeed/AnswerCard.jsx
+++ b/src/components/feed/answerFeed/AnswerCard.jsx
@@ -98,7 +98,7 @@ function AnswerCard({
       </StyledAnswerCardUpperArea>
       <QuestionTitle question={questionContent} questionCreateAt={questionCreateAt} />
       <AnswerTemplate answerCreatedAt={answerCreatedAt}>{renderAnswerContent()}</AnswerTemplate>
-      <Reaction likeCount={likeCount} dislikeCount={dislikeCount} />
+      <Reaction likeCount={likeCount} dislikeCount={dislikeCount} questionId={questionId} />
     </StyledFeedCardContainer>
   );
 }

--- a/src/components/feed/answerFeed/AnswerCard.jsx
+++ b/src/components/feed/answerFeed/AnswerCard.jsx
@@ -65,16 +65,20 @@ function AnswerCard({
     if (answer?.isRejected) {
       // 답변 거절의 경우
       return <StyledAnswerText $isRejected>답변 거절</StyledAnswerText>;
-    } else if (isEditing) {
+    }
+
+    if (isEditing) {
       // 답변 거절은 아니지만, 수정 하기 버튼을 누른 경우
       return <AnswerForm currentAnswer={currentAnswer} buttonText="수정 완료" onSubmitForm={handleEditFormSubmit} />;
-    } else if (!currentAnswer) {
+    }
+
+    if (!currentAnswer) {
       // 답변 거절도 아니고, 수정중도 아니지만, 받아온 답변이 빈값인 경우
       return <AnswerForm currentAnswer={currentAnswer} buttonText="답변 완료" onSubmitForm={handleCreateFormSubmit} />;
-    } else {
-      // 답변 거절도 아니고, 수정중도 아니지만, 받아온 답변이 존재하는 경우
-      return <StyledAnswerText>{currentAnswer}</StyledAnswerText>;
     }
+
+    // 답변 거절도 아니고, 수정중도 아니고, 받아온 답변이 빈값도 아닌 경우
+    return <StyledAnswerText>{currentAnswer}</StyledAnswerText>;
   };
 
   return (

--- a/src/components/feed/answerFeed/MoreButton.jsx
+++ b/src/components/feed/answerFeed/MoreButton.jsx
@@ -1,10 +1,14 @@
 import styled from 'styled-components';
 import moreIcon from '../../../assets/images/more-icon.png';
 
-function MoreButton() {
+function MoreButton({ onEditButtonClick, onRejectButtonToggle }) {
   return (
-    <StyledMoreButton>
+    <StyledMoreButton style={{ position: 'relative' }}>
       <img src={moreIcon} alt={'더보기 아이콘'} />
+      <ul style={{ width: '60px', position: 'absolute', backgroundColor: 'aliceblue' }}>
+        <li onClick={onEditButtonClick}>답변 수정</li>
+        <li onClick={onRejectButtonToggle}>답변 거절</li>
+      </ul>
     </StyledMoreButton>
   );
 }

--- a/src/components/feed/questionFeed/QuestionCard.jsx
+++ b/src/components/feed/questionFeed/QuestionCard.jsx
@@ -7,6 +7,7 @@ import Reaction from '../Reaction';
 /**
  * 질문 피드 페이지에서의 질문 카드
  * @param props
+ * @param {string} props.questionId 질문 id
  * @param {string} props.questionContent 질문 내용
  * @param {integer} props.likeCount 좋아요 수
  * @param {integer} props.dislikeCount 싫어요 수
@@ -15,6 +16,7 @@ import Reaction from '../Reaction';
  */
 function QuestionCard({
   // TODO: 상위 컴포넌트에서 데이터를 넣어줄 수 있게 되면 테스트용 기본값 삭제 예정
+  questionId,
   questionContent = '좋아하는 동물은?좋아하는 동물은?좋아하는 동물은? 좋아하동 물은?',
   likeCount = 0,
   dislikeCount = 0,
@@ -36,7 +38,7 @@ function QuestionCard({
           )}
         </AnswerTemplate>
       )}
-      <Reaction likeCount={likeCount} dislikeCount={dislikeCount} />
+      <Reaction likeCount={likeCount} dislikeCount={dislikeCount} questionId={questionId} />
     </StyledFeedCardContainer>
   );
 }

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -1,3 +1,4 @@
 export const SUBJECTS_QUERY_KEY = 'subjects';
 export const ANSWERS_QUERY_KEY = 'answers';
 export const QUESTIONS_QUERY_KEY = 'questions';
+export const REACTION_QUERY_KEY = 'reaction';

--- a/src/queries/useReactionMutation.js
+++ b/src/queries/useReactionMutation.js
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import postReaction from '../apis/postReaction';
+import { REACTION_QUERY_KEY } from '../constants/queryKeys';
+
+const useSelectReactionMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ questionId, type }) => postReaction({ questionId, type }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [REACTION_QUERY_KEY], exact: true, refetchType: 'none' });
+      // 캐시를 무효화하지만 당장 서버로부터 재요청을 하지는 않음
+    },
+  });
+};
+
+export default useSelectReactionMutation;

--- a/src/queries/useUpdateAnswerMutation.js
+++ b/src/queries/useUpdateAnswerMutation.js
@@ -5,7 +5,7 @@ import { ANSWERS_QUERY_KEY } from '../constants/queryKeys';
 const useUpdateAnswerMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ answerId, content }) => putAnswer({ answerId, content }),
+    mutationFn: ({ answerId, content, isRejected }) => putAnswer({ answerId, content, isRejected }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [ANSWERS_QUERY_KEY], exact: true, refetchType: 'none' });
     },

--- a/src/styles/feed/feedCardStyles.js
+++ b/src/styles/feed/feedCardStyles.js
@@ -71,7 +71,7 @@ export const jelloHorizontal = keyframes`
 `;
 
 export const jelloHorizontalAnimation = css`
-  animation: ${jelloHorizontal} 0.9s both;
+  animation: ${jelloHorizontal} 1.1s cubic-bezier(0.165, 0.84, 0.44, 1) both;
 `;
 export const shakeLeftAnimation = css`
   animation: ${shakeLeft} 0.7s cubic-bezier(0.455, 0.03, 0.515, 0.955) both;

--- a/src/styles/feed/feedCardStyles.js
+++ b/src/styles/feed/feedCardStyles.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
 export const StyledFeedCardContainer = styled.div`
   display: flex;
@@ -6,7 +6,7 @@ export const StyledFeedCardContainer = styled.div`
   gap: 32px;
 
   max-width: 684px;
-  padding: 32px;
+  padding: 32px 32px 20px 32px;
 
   box-shadow: var(--shadow1pt);
   border-radius: 16px;
@@ -17,4 +17,62 @@ export const StyledAnswerText = styled.p`
   font-weight: 400;
   line-height: 22px;
   color: ${({ $isRejected }) => $isRejected && 'var(--red)'};
+`;
+
+export const shakeLeft = keyframes`
+  0%,
+  100% {
+    transform: rotate(0deg);
+    transform-origin: 0 50%;
+  }
+  10% {
+    transform: rotate(6deg);
+  }
+  20%,
+  40%,
+  60% {
+    transform: rotate(-8deg);
+  }
+  30%,
+  50%,
+  70% {
+    transform: rotate(8deg);
+  }
+  80% {
+    transform: rotate(-6deg);
+  }
+  90% {
+    transform: rotate(6deg);
+  }
+`;
+
+export const jelloHorizontal = keyframes`
+0% {
+  transform: scale3d(1, 1, 1);
+}
+30% {
+  transform: scale3d(1.25, 0.75, 1);
+}
+40% {
+  transform: scale3d(0.75, 1.25, 1);
+}
+50% {
+  transform: scale3d(1.15, 0.85, 1);
+}
+65% {
+  transform: scale3d(0.95, 1.05, 1);
+}
+75% {
+  transform: scale3d(1.05, 0.95, 1);
+}
+100% {
+  transform: scale3d(1, 1, 1);
+}
+`;
+
+export const jelloHorizontalAnimation = css`
+  animation: ${jelloHorizontal} 0.9s both;
+`;
+export const shakeLeftAnimation = css`
+  animation: ${shakeLeft} 0.7s cubic-bezier(0.455, 0.03, 0.515, 0.955) both;
 `;


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 답변 피드 카드 추가 구현

## 📝 작업 내용 설명
- 질문 피드 카드와 답변 피드 카드의 컴포넌트 폴더 구조 개편
  - <img width="235" alt="image" src="https://github.com/user-attachments/assets/3dd22aab-1eb3-4a94-8feb-821e189abe67">
  - 질문과 답변 피드 페이지에서 공통으로 쓰이는 컴포넌트들은 components/feed 폴더에 넣고,
  질문 피드 카드에만 쓰이는 컴포넌트는 questionFeed 폴더에,
  답변 피드 카드에만 쓰이는 컴포넌트는 answerFeed 폴더에 넣어서 논리적으로 그룹화
- 더미 컴포넌트로 더보기 기능을 구현 => 향후 @leehj322 님이 만든 공용 드롭다운 컴포넌트로 교체 예정
  - <img width="225" alt="image" src="https://github.com/user-attachments/assets/dd6a0d78-de99-4966-9508-4ea11185090b">
- 불필요한 else if 구문 삭제
  -  <img width="1120" alt="image" src="https://github.com/user-attachments/assets/3ba96973-fcd4-4590-bd72-f9ba95d28cf0">
- 좋아요 기능 및 마이크로 인터랙션 애니메이션 구현
![화면 기록 2024-07-18 오후 5 16 53](https://github.com/user-attachments/assets/aaa0935b-26c3-4da8-a734-8db276bfb839)
  - 좋아요가 눌러지기 전에는 호버링할 때만 색상이 변하며, 좋아요 따봉 아이콘이 위 아래로 흔들립니다.
  - 클릭 시 로컬 스토리지에 사용자가 리액션한 객체에서 키값으로 아이디를 찾고,
  해당 아이디가 없으면 새로운 값으로 추가해줍니다.
  만약 로컬 스토리지에 해당 아이디로 키값이 있었다면, 카드를 볼 때부터 선택했던 리액션이 하이라이트 되어 있을 겁니다.
  이미 선택된 좋아요라면 위아래로 흔들리는 대신 튀어오르는 애니메이션이 실행됩니다. 
  - 싫어요는 따로 애니메이션은 없으며 호버링 시 색상이 변하고, 클릭 시 변한 색상이 유지됩니다.
  - 서버로의 요청이 성공하지 않아도, 좋아요 개수는 올라가며, 성공한 후에도 서버에 전체 데이터 재요청없이,
  다음 번 요청부터 반영되도록 캐시만 무효화 시킵니다.

## 🏷️ 연관된 Jira 티켓 번호
> [VJNP-78](https://fe08team4.atlassian.net/browse/VJNP-78)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내가 만든 함수에 JSDOC을 작성하였습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.


[VJNP-78]: https://fe08team4.atlassian.net/browse/VJNP-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ