### PR TITLE
VJNP-105: 그리드 레이아웃 쉬프트 제거

### DIFF
--- a/src/components/SubjectSelection/StyledSubjectGrid.jsx
+++ b/src/components/SubjectSelection/StyledSubjectGrid.jsx
@@ -4,6 +4,7 @@ import { GRID_BREAKPOINT } from '../../constants/subjectGrid';
 const StyledSubjectGrid = styled.ol`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(2, 187px);
   gap: 20px;
 
   @media screen and (max-width: ${GRID_BREAKPOINT.tablet}px) {
@@ -12,6 +13,7 @@ const StyledSubjectGrid = styled.ol`
 
   @media screen and (min-width: 375px) and (max-width: ${GRID_BREAKPOINT.mobile}px) {
     grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(3, 187px);
   }
 `;
 


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> 그리드 레이아웃 쉬프트 제거

## 📝 작업 내용 설명
> 그리드 높이를 일정하게 해서 레이아웃 쉬프트를 제거 했습니다.

## 📷 스크린샷
(없음)

## 💬 리뷰 요구사항
> 높이값만 추가해서 제거한거라 특이사항 없습니다

## 🏷️ 연관된 Jira 티켓 번호
> https://fe08team4.atlassian.net/browse/VJNP-105

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내가 만든 함수에 JSDOC을 작성하였습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
