### PR TITLE
VJNP-72: 완성된 컴포넌트를 활용하여 질문 페이지 완성

### DIFF
--- a/src/components/feed/questionFeed/QuestionCardList.jsx
+++ b/src/components/feed/questionFeed/QuestionCardList.jsx
@@ -36,7 +36,7 @@ function QuestionCardList({ questionCount, subjectId }) {
   // useInfiniteQuery 훅을 사용하여 무한 스크롤 데이터를 관리
   const { data, fetchNextPage, hasNextPage, isLoading, isError } = useInfiniteQuery({
     queryKey: ['questions', subjectId],
-    queryFn: async ({ pageParam = 1 }) => {
+    queryFn: async ({ pageParam = 0 }) => {
       try {
         // subjectId가 없으면 빈 데이터를 반환하여 오류 방지
         if (!subjectId) {
@@ -57,7 +57,10 @@ function QuestionCardList({ questionCount, subjectId }) {
     // 마지막 페이지의 실제 데이터 수를 기반으로 계산
     // lastPage.results.length: 현재 페이지의 데이터 수
     getNextPageParam: (lastPage, allPages) => {
-      return lastPage.results.length === 0 ? undefined : allPages.length + 1;
+      const currentPage = allPages.length; // 현재 페이지 번호
+      const nextPageHasData = lastPage.results.length > 0; // 다음 페이지에 데이터가 있는지 여부
+
+      return nextPageHasData ? currentPage : undefined;
     },
   });
 

--- a/src/components/feed/questionFeed/ResponsiveText.jsx
+++ b/src/components/feed/questionFeed/ResponsiveText.jsx
@@ -1,0 +1,31 @@
+import React, { useState, useEffect } from 'react';
+
+const ResponsiveText = () => {
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    // 컴포넌트가 언마운트될 때 리사이즈 이벤트 리스너 제거
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  // 화면 크기에 따라 다른 텍스트 반환
+  const getText = () => {
+    if (windowWidth >= 768) {
+      return '질문 작성하기';
+    } else {
+      return '질문 작성';
+    }
+  };
+
+  return <>{getText()}</>;
+};
+
+export default ResponsiveText;

--- a/src/pages/QuestionFeed.jsx
+++ b/src/pages/QuestionFeed.jsx
@@ -9,6 +9,7 @@ import Header from '../components/feed/questionFeed/Header';
 import QuestionCardList from '../components/feed/questionFeed/QuestionCardList';
 import { StyledFeedCardListContainer } from '../styles/feed/feedCardListStyles';
 import { StyledQuestionCountArea } from '../styles/feed/questionCountStyles';
+import { StyledHeroImg } from '../styles/feed/heroImgStyles';
 import { StyledMessagesImg } from '../styles/feed/messagesImgStyles';
 import { StyledNoQuestionImg } from '../styles/feed/noQuestionImgStyles';
 
@@ -16,7 +17,7 @@ const StyledQuestionFeedPageContainer = styled.div`
   margin: 0px auto;
   width: 1200px;
 
-  background-color: var(--gray20);
+  background-color: ${({ theme }) => theme.gray20};
 
   position: relative;
 
@@ -33,15 +34,6 @@ const StyledHeroImgWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-`;
-
-const StyledHeroImg = styled.img`
-  width: 1200px;
-  height: 234px;
-
-  @media screen and (min-width: 375px) and (max-width: 767px) {
-    height: 177px;
-  }
 `;
 
 function QuestionFeed() {

--- a/src/pages/QuestionFeed.jsx
+++ b/src/pages/QuestionFeed.jsx
@@ -12,6 +12,9 @@ import { StyledQuestionCountArea } from '../styles/feed/questionCountStyles';
 import { StyledHeroImg } from '../styles/feed/heroImgStyles';
 import { StyledMessagesImg } from '../styles/feed/messagesImgStyles';
 import { StyledNoQuestionImg } from '../styles/feed/noQuestionImgStyles';
+import Button from '../components/@shared/Button';
+import ResponsiveText from '../components/feed/questionFeed/ResponsiveText';
+import ModalComponent from '../components/feed/questionFeed/ModalComponent';
 
 const StyledQuestionFeedPageContainer = styled.div`
   margin: 0px auto;
@@ -36,6 +39,19 @@ const StyledHeroImgWrapper = styled.div`
   align-items: center;
 `;
 
+const questionButtonStyle = {
+  fontSize: '20px',
+  boxShadow: 'var(--shadow2pt)',
+  position: 'fixed',
+  right: '24px',
+  bottom: '24px',
+
+  '@media screen and (min-width: 375px) and (max-width: 767px)': {
+    width: '123px',
+    height: '54px',
+  },
+};
+
 function QuestionFeed() {
   // 세션 스토리지에서 반환된 값 역직렬화
   const profileDataString = sessionStorage.getItem('profile');
@@ -59,6 +75,10 @@ function QuestionFeed() {
         {/* Header, QuestionCardList 컴포넌트에 데이터를 props로 전달 */}
         <Header name={name} imageSource={imageSource} />
         <QuestionCardList subjectId={id} questionCount={questionCount} />
+        <Button onClick shape={'pill'} btnColor={'deep'} style={questionButtonStyle} width={'208px'} height={'54px'}>
+          <ResponsiveText />
+          <ModalComponent name={name} imageSource={imageSource} />
+        </Button>
       </StyledQuestionFeedPageContainer>
     );
   } else {
@@ -76,6 +96,10 @@ function QuestionFeed() {
             아직 질문이 없습니다
           </StyledQuestionCountArea>
           <StyledNoQuestionImg src={noQuestionImg} alt="빈 박스 이미지" />
+          <Button onClick shape={'pill'} btnColor={'deep'} style={questionButtonStyle} width={'208px'} height={'54px'}>
+            <ResponsiveText />
+            <ModalComponent name={name} imageSource={imageSource} />
+          </Button>
         </StyledFeedCardListContainer>
       </StyledQuestionFeedPageContainer>
     );

--- a/src/styles/feed/feedCardListStyles.js
+++ b/src/styles/feed/feedCardListStyles.js
@@ -5,13 +5,13 @@ export const StyledFeedCardListContainer = styled.div`
   flex-direction: column;
   gap: 20px;
 
-  background-color: var(--brown10);
+  background-color: ${({ theme }) => theme.brown10};
 
   max-width: 716px;
   margin: 189px auto 136px;
   padding: 16px;
 
-  border: 1px solid var(--brown30);
+  border: 1px solid ${({ theme }) => theme.brown30};
   border-radius: 16px;
 
   @media screen and (min-width: 768px) and (max-width: 1199px) {

--- a/src/styles/feed/heroImgStyles.js
+++ b/src/styles/feed/heroImgStyles.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const StyledHeroImg = styled.img`
+  width: 1200px;
+  height: 234px;
+
+  @media screen and (min-width: 375px) and (max-width: 767px) {
+    height: 177px;
+  }
+`;

--- a/src/styles/feed/questionCountStyles.js
+++ b/src/styles/feed/questionCountStyles.js
@@ -9,7 +9,7 @@ export const StyledQuestionCountArea = styled.div`
   font-size: 20px;
   font-weight: 400;
   text-align: center;
-  color: var(--brown40);
+  color: ${({ theme }) => theme.brown40};
 
   @media screen and (min-width: 375px) and (max-width: 767px) {
     font-size: 18px;


### PR DESCRIPTION
## ✏️ 작업 내용 요약
> dev 브랜치에 있던 임시 컴포넌트들로 질문 페이지를 완성했습니다.

## 📝 작업 내용 설명
> 1. 무한 스크롤이 데이터를 제대로 불러오지 못하는 것을 발견하여 getNextPageParam 함수를 리팩토링하여 문제를 해결하였습니다.
> 2. 공통 버튼과 모달을 활용하여 질문 버튼을 제작했습니다. (임시)
> 3. 완성된 컴포넌트가 머지되면 pull 받아와서 프로필 영역, 모달과 같이 임시로 만든 컴포넌트를 완성된 컴포넌트로 갈아끼우기만 하면 됩니다.

## 📷 스크린샷
![임시 컴포넌트들로 완성한 질문 페이지](https://github.com/user-attachments/assets/51a79c7f-ea0b-4c96-8022-c3f2275e40a8)

## 💬 리뷰 요구사항
> 질문 버튼에 텍스트가 같이 보이는 부분은 완성된 모달 컴포넌트에서 display: none과 같은 것으로 처리해줄 예정입니다. 이외에도 고쳐야될 부분, 개선했으면 하는 부분이 있다면 알려주세요!

## 🏷️ 연관된 Jira 티켓 번호
> [https://fe08team4.atlassian.net/browse/VJNP-72](url)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [ ] 내가 만든 함수에 JSDOC을 작성하였습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
