### PR TITLE
VJNP-114: sessionStorage를 더 이상 사용하지 않게 되면서 잔재된 버그 수정

### DIFF
--- a/src/components/feed/AnswerTemplate.jsx
+++ b/src/components/feed/AnswerTemplate.jsx
@@ -1,8 +1,9 @@
 import { styled } from 'styled-components';
-import profileImg from '../../assets/images/samples/profile-sample.png';
 import getElapsedPeriod from '../../utils/getElapsedPeriod';
 import { MEDIA_QUERY_SIZES } from '../../constants/mediaQuerySizes';
 import { getThemeColor } from '../../utils/getThemeColor';
+import { useParams } from 'react-router-dom';
+import useSubjectQuery from '../../hooks/useSubjectQuery';
 
 /**
  * 답변자의 프로필과 질문 시점으로부터 지난 기간을 보여주고, 답변 내용을 담을 템플릿
@@ -11,8 +12,10 @@ import { getThemeColor } from '../../utils/getThemeColor';
  * @param {string} props.answerCreatedAt 답변 생성 시기
  */
 function AnswerTemplate({ children, answerCreatedAt }) {
-  const profile = JSON.parse(sessionStorage.getItem('profile'));
-  const { imageSource, name } = profile || { imageSource: profileImg, name: '아초는 고양이' };
+  const { id: subjectId } = useParams(); // useParams 이용해서 subjectId 가져오기
+  const {
+    data: { imageSource, name },
+  } = useSubjectQuery(subjectId);
   const elapsedPeriod = answerCreatedAt ? getElapsedPeriod(answerCreatedAt) : ''; // 아직 답변이 없는 경우
 
   return (

--- a/src/components/feed/Reaction.jsx
+++ b/src/components/feed/Reaction.jsx
@@ -14,7 +14,7 @@ import { getThemeColor } from '../../utils/getThemeColor';
  * @param {integer} props.likeCount 좋아요 수
  * @param {string} props.questionId 질문 id
  */
-function Reaction({ likeCount, questionId = '123424' }) {
+function Reaction({ likeCount, questionId }) {
   // TODO: '123424'는 테스트값이므로 향후 삭제 예정
   const reactionList = JSON.parse(localStorage.getItem('reactionList'));
 

--- a/src/components/feed/answerFeed/AnswerCard.jsx
+++ b/src/components/feed/answerFeed/AnswerCard.jsx
@@ -25,10 +25,10 @@ import showToast from '../../@shared/Toast';
 function AnswerCard({
   // TODO: 상위 컴포넌트에서 데이터를 넣어줄 수 있게 되면 테스트용 기본값 삭제 예정
   questionId,
-  questionContent = '좋아하는 동물은?좋아하는 동물은?좋아하는 동물은? 좋아하동 물은?',
-  likeCount = 0,
-  dislikeCount = 0,
-  questionCreateAt = '',
+  questionContent,
+  likeCount,
+  dislikeCount,
+  questionCreateAt,
   answer,
 }) {
   const isHasAnswer = !!answer;

--- a/src/components/feed/questionFeed/ModalComponent.jsx
+++ b/src/components/feed/questionFeed/ModalComponent.jsx
@@ -26,7 +26,6 @@ function ModalComponent({ profileImg, name, isOpen, onRequestClose, subjectId })
       .post(`https://openmind-api.vercel.app/8-4/subjects/${subjectId}/questions/`, request)
       .then(response => {
         console.log('handleAxiosRequest', response);
-        sessionStorage.setItem('profile', JSON.stringify(response.data));
         onRequestClose();
         window.location.reload(); //새로고침
         // navigate(`/post/${response.data.subjectId}`);

--- a/src/components/feed/questionFeed/QuestionCard.jsx
+++ b/src/components/feed/questionFeed/QuestionCard.jsx
@@ -17,10 +17,10 @@ import Reaction from '../Reaction';
 function QuestionCard({
   // TODO: 상위 컴포넌트에서 데이터를 넣어줄 수 있게 되면 테스트용 기본값 삭제 예정
   questionId,
-  questionContent = '좋아하는 동물은?좋아하는 동물은?좋아하는 동물은? 좋아하동 물은?',
-  likeCount = 0,
-  dislikeCount = 0,
-  questionCreateAt = '2024-07-05',
+  questionContent,
+  likeCount,
+  dislikeCount,
+  questionCreateAt,
   answer,
 }) {
   const isHasAnswer = !!answer;

--- a/src/components/subjectSelection/SubjectCard.jsx
+++ b/src/components/subjectSelection/SubjectCard.jsx
@@ -1,6 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 import receivedQuestionIcon from '../../assets/images/messages_icon.png';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 const waveAnimation = keyframes`
   0% {
@@ -14,7 +14,7 @@ const waveAnimation = keyframes`
   }
 `;
 
-const StyledQuestionCardContainer = styled.li`
+const StyledQuestionCardContainer = styled(Link)`
   width: 100%;
   min-width: 112px;
   height: 187px;
@@ -95,25 +95,8 @@ const StyledReceivedQuestionText = styled.p`
 `;
 
 function SubjectCard({ subject }) {
-  const navigate = useNavigate();
-
-  const handleClick = () => {
-    if (subject) {
-      const profile = {
-        id: subject.id,
-        name: subject.name,
-        imageSource: subject.imageSource,
-        questionCount: subject.questionCount,
-        createdAt: subject.createdAt,
-      };
-
-      sessionStorage.setItem('profile', JSON.stringify(profile));
-      navigate(`/post/${subject.id}`);
-    }
-  };
-
   return (
-    <StyledQuestionCardContainer onClick={handleClick}>
+    <StyledQuestionCardContainer to={`/post/${subject.id}`}>
       <StyledProfileImg src={subject.imageSource} alt="답변자 프로필 사진" />
       <StyledUserName>{subject.name}</StyledUserName>
       <StyledReceivedQuestionArea>


### PR DESCRIPTION
## ✏️ 작업 내용 요약
>  sessionStorage를 더 이상 사용하지 않게 되면서 잔재된 버그 수정

## 📝 작업 내용 설명
- 답변자의 프로필 사진과 이름을 렌더링하는 AnswerTemplate 컴포넌트의 답변자 데이터 가져오기 로직 변경
: 답변자 프로필 정보를 sessionStrage에서 가져오던 것을 url 스트링으로 쿼리 요청하여 가져오는 것으로 변경
- 컴포넌트 테스트용으로 넣어두었던 질문 및 답변 카드 컴포넌트의 파라미터 기본값 제거

## 🏷️ 연관된 Jira 티켓 번호
> [VJNP-114](https://fe08team4.atlassian.net/browse/VJNP-114)

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내가 만든 함수에 JSDOC을 작성하였습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.


[VJNP-114]: https://fe08team4.atlassian.net/browse/VJNP-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ